### PR TITLE
Remove unused prop isMobile

### DIFF
--- a/front-end/src/Numbers/NumberContainer.js
+++ b/front-end/src/Numbers/NumberContainer.js
@@ -22,7 +22,7 @@ class NumberContainer extends React.Component {
 
   render () {
     return (
-      <NumberListContainer isMobile={true}>
+      <NumberListContainer>
         {this.state.numberList.map(num => (
           <WaitingNumber key={num} isAdmin={this.props.isAdmin} number={num}/>
         ))}


### PR DESCRIPTION
Found this while looking at some other stuff. WDYT? Do we still need this for something you have intended in the future @OskarDamkjaer, or is it simply something that has been left over after refactoring? :) 