### PR TITLE
Suggestion: Refactor input field

### DIFF
--- a/front-end/src/AdminBar/AdminView.js
+++ b/front-end/src/AdminBar/AdminView.js
@@ -39,6 +39,11 @@ class AdminView extends React.Component {
 
   componentDidMount() {
     this.focusInput();
+    window.addEventListener("focus", this.focusInput);
+  }
+
+  componentWillUnmount() {
+    window.addEventListener("focus", this.focusInput);
   }
 
   render() {

--- a/front-end/src/AdminBar/AdminView.js
+++ b/front-end/src/AdminBar/AdminView.js
@@ -1,13 +1,6 @@
 import React from "react";
 import { addOrRemove, clear } from "../utils/api";
 import { AdminPanel, FocusInput, ColoredButton } from "./adminStyles";
-import {
-  ESCAPE_KEY,
-  ENTER_KEY,
-  NUMPAD_ENTER_KEY,
-  BACKSPACE,
-  DELETE
-} from "../utils/keypadNumbers";
 
 class AdminView extends React.Component {
   constructor(props) {
@@ -16,24 +9,22 @@ class AdminView extends React.Component {
   }
 
   // Implemented this way to always accept input!
-  handleKeyDown = event => {
-    const keyCode = event.keyCode;
-    switch (keyCode) {
-      case ESCAPE_KEY:
+  handleKeyDown = ({ key }) => {
+    switch (key) {
+      case "Escape":
         this.setState({ typed: "" });
         break;
-      case ENTER_KEY:
-      case NUMPAD_ENTER_KEY:
+      case "Enter":
         this.sendNumber();
         break;
-      case DELETE:
-      case BACKSPACE:
+      case "Del":
+      case "Backspace":
         this.setState({
           typed: this.state.typed.substring(0, this.state.typed.length - 1)
         });
         break;
       default:
-        this.handleIfNumber(keyCode);
+        this.handleIfNumber(key);
     }
   };
 
@@ -78,7 +69,7 @@ class AdminView extends React.Component {
         <ColoredButton color="#dbafc1" area="clear" onClick={clear}>
           rensa
         </ColoredButton>
-        <FocusInput value={this.state.typed} type="number" />
+        <FocusInput value={this.state.typed} type="number"/>
         <ColoredButton color="#b4d2ba" area="undo" onClick={this.undo}>
           :)
         </ColoredButton>

--- a/front-end/src/AdminBar/AdminView.js
+++ b/front-end/src/AdminBar/AdminView.js
@@ -24,6 +24,12 @@ class AdminView extends React.Component {
     }
   };
 
+  clearOnEscape = (event) => {
+    if (event.key === "Escape") {
+      this.setState({ typed: "" });
+    }
+  }
+
   onFormSubmit(event) {
     event.preventDefault();
     this.sendNumber();
@@ -61,6 +67,7 @@ class AdminView extends React.Component {
           value={this.state.typed}
           onChange={this.updateTyped}
           onBlur={this.focusInput}
+          onKeyDown={this.clearOnEscape}
           ref={this.inputRef}
           maxLength={MAX_NUMBER_LENGTH}
           autoFocus

--- a/front-end/src/AdminBar/AdminView.js
+++ b/front-end/src/AdminBar/AdminView.js
@@ -2,31 +2,15 @@ import React from "react";
 import { addOrRemove, clear } from "../utils/api";
 import { AdminPanel, FocusInput, ColoredButton } from "./adminStyles";
 
+const filterNumeric = str => str.replace(/\D/g,'');
+
 class AdminView extends React.Component {
   constructor(props) {
     super(props);
     this.state = { typed: "" };
+    this.inputRef = React.createRef();
+    this.updateTyped = this.updateTyped.bind(this);
   }
-
-  // Implemented this way to always accept input!
-  handleKeyDown = ({ key }) => {
-    switch (key) {
-      case "Escape":
-        this.setState({ typed: "" });
-        break;
-      case "Enter":
-        this.sendNumber();
-        break;
-      case "Del":
-      case "Backspace":
-        this.setState({
-          typed: this.state.typed.substring(0, this.state.typed.length - 1)
-        });
-        break;
-      default:
-        this.handleIfNumber(key);
-    }
-  };
 
   sendNumber = () => {
     this.sendNumberWithParam(this.state.typed);
@@ -41,26 +25,17 @@ class AdminView extends React.Component {
     }
   };
 
-  undo = () => {
-    // Not yet implemented use redux
-  };
-
-  handleIfNumber(keyCode) {
-    if (this.state.typed.length < 8) {
-      // max len accpt by backend
-      const inputSymbol = String.fromCharCode(keyCode);
-      if (inputSymbol && !isNaN(inputSymbol)) {
-        this.setState({ typed: this.state.typed.concat(inputSymbol) });
-      }
-    }
+  focusInput = () => {
+    // setTimeout hack necessary to prevent browsers blocking this behaviour
+    setTimeout(() => this.inputRef.current.focus(), 1);
   }
 
-  componentWillMount() {
-    document.addEventListener("keydown", this.handleKeyDown.bind(this));
+  updateTyped = (event) => {
+    this.setState({ typed: filterNumeric(event.target.value) });
   }
 
-  componentWillUnmount() {
-    document.removeEventListener("keydown", this.handleKeyDown.bind(this));
+  componentDidMount() {
+    this.focusInput();
   }
 
   render() {
@@ -69,7 +44,15 @@ class AdminView extends React.Component {
         <ColoredButton color="#dbafc1" area="clear" onClick={clear}>
           rensa
         </ColoredButton>
-        <FocusInput value={this.state.typed} type="number"/>
+        <FocusInput
+          type="tel"
+          pattern="[0-9]*"
+          inputMode="numeric"
+          value={this.state.typed}
+          onChange={this.updateTyped}
+          onBlur={this.focusInput}
+          ref={this.inputRef}
+        />
         <ColoredButton color="#b4d2ba" area="undo" onClick={this.undo}>
           :)
         </ColoredButton>

--- a/front-end/src/AdminBar/AdminView.js
+++ b/front-end/src/AdminBar/AdminView.js
@@ -10,7 +10,6 @@ class AdminView extends React.Component {
     super(props);
     this.state = { typed: "" };
     this.inputRef = React.createRef();
-    this.onFormSubmit = this.onFormSubmit.bind(this);
   }
 
   sendNumber = () => {
@@ -28,22 +27,22 @@ class AdminView extends React.Component {
     if (event.key === "Escape") {
       this.setState({ typed: "" });
     }
-  }
+  };
 
-  onFormSubmit(event) {
+  onFormSubmit = (event) => {
     event.preventDefault();
     this.sendNumber();
-  }
+  };
 
   focusInput = () => {
     // setTimeout hack necessary to prevent browsers blocking this behaviour
     setTimeout(() => this.inputRef.current.focus(), 1);
-  }
+  };
 
   updateTyped = (event) => {
     const typed = filterNumeric(event.target.value).substring(0, MAX_NUMBER_LENGTH);
     this.setState({ typed });
-  }
+  };
 
   componentDidMount() {
     this.focusInput();

--- a/front-end/src/AdminBar/AdminView.js
+++ b/front-end/src/AdminBar/AdminView.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { addOrRemove, clear } from "../utils/api";
-import { AdminPanel, FocusInput, ColoredButton } from "./adminStyles";
+import { AdminForm, FocusInput, ColoredButton } from "./adminStyles";
 
 const filterNumeric = str => str.replace(/\D/g,'');
 
@@ -9,7 +9,7 @@ class AdminView extends React.Component {
     super(props);
     this.state = { typed: "" };
     this.inputRef = React.createRef();
-    this.updateTyped = this.updateTyped.bind(this);
+    this.onFormSubmit = this.onFormSubmit.bind(this);
   }
 
   sendNumber = () => {
@@ -19,11 +19,14 @@ class AdminView extends React.Component {
   sendNumberWithParam = num => {
     if (num.length > 0) {
       addOrRemove(num);
-      this.setState({
-        typed: ""
-      });
+      this.setState({ typed: "" });
     }
   };
+
+  onFormSubmit(event) {
+    event.preventDefault();
+    this.sendNumber();
+  }
 
   focusInput = () => {
     // setTimeout hack necessary to prevent browsers blocking this behaviour
@@ -40,8 +43,8 @@ class AdminView extends React.Component {
 
   render() {
     return (
-      <AdminPanel>
-        <ColoredButton color="#dbafc1" area="clear" onClick={clear}>
+      <AdminForm onSubmit={this.onFormSubmit}>
+        <ColoredButton color="#dbafc1" area="clear" onClick={clear} type="button">
           rensa
         </ColoredButton>
         <FocusInput
@@ -53,13 +56,13 @@ class AdminView extends React.Component {
           onBlur={this.focusInput}
           ref={this.inputRef}
         />
-        <ColoredButton color="#b4d2ba" area="undo" onClick={this.undo}>
+        <ColoredButton color="#b4d2ba" area="undo" onClick={this.undo} type="button">
           :)
         </ColoredButton>
-        <ColoredButton color="#8ed081" area="send" onClick={this.sendNumber}>
+        <ColoredButton color="#8ed081" area="send" onClick={this.sendNumber} type="submit">
           send
         </ColoredButton>
-      </AdminPanel>
+      </AdminForm>
     );
   }
 }

--- a/front-end/src/AdminBar/AdminView.js
+++ b/front-end/src/AdminBar/AdminView.js
@@ -2,6 +2,7 @@ import React from "react";
 import { addOrRemove, clear } from "../utils/api";
 import { AdminForm, FocusInput, ColoredButton } from "./adminStyles";
 
+const MAX_NUMBER_LENGTH = 8;
 const filterNumeric = str => str.replace(/\D/g,'');
 
 class AdminView extends React.Component {
@@ -34,7 +35,8 @@ class AdminView extends React.Component {
   }
 
   updateTyped = (event) => {
-    this.setState({ typed: filterNumeric(event.target.value) });
+    const typed = filterNumeric(event.target.value).substring(0, MAX_NUMBER_LENGTH);
+    this.setState({ typed });
   }
 
   componentDidMount() {
@@ -60,6 +62,8 @@ class AdminView extends React.Component {
           onChange={this.updateTyped}
           onBlur={this.focusInput}
           ref={this.inputRef}
+          maxLength={MAX_NUMBER_LENGTH}
+          autoFocus
         />
         <ColoredButton color="#b4d2ba" area="undo" onClick={this.undo} type="button">
           :)

--- a/front-end/src/AdminBar/adminStyles.js
+++ b/front-end/src/AdminBar/adminStyles.js
@@ -1,20 +1,20 @@
 import styled from "styled-components";
 
-export const AdminPanel = styled.div`
+export const AdminForm = styled.form`
   grid-area: header;
   display: grid;
-  width: 96%; 
+  width: 96%;
   padding: 2%;
   grid-template-columns 1fr 6fr 1fr 1fr;
   grid-template-areas: "clear currentInput send undo";
-  
+
   @media (max-width: 700px) {
     grid-template-rows: 1fr 1fr;
     grid-template-columns: 1fr 1fr 1fr;
     grid-template-areas:
      "clear undo send"
      "currentInput currentInput currentInput";
-    width: 100%; 
+    width: 100%;
     padding: 0;
   }
 `;

--- a/front-end/src/AdminBar/adminStyles.js
+++ b/front-end/src/AdminBar/adminStyles.js
@@ -40,4 +40,6 @@ export const FocusInput = styled.input`
   border: none;
   height: 100%;
   width: 100%;
+  padding: 0 0.25em;
+  box-sizing: border-box;
 `;

--- a/front-end/src/utils/keypadNumbers.js
+++ b/front-end/src/utils/keypadNumbers.js
@@ -1,5 +1,0 @@
-export const ESCAPE_KEY = 27;
-export const ENTER_KEY = 13;
-export const NUMPAD_ENTER_KEY = 176;
-export const BACKSPACE = 8;
-export const DELETE = 46;


### PR DESCRIPTION
This PR fixes #27 and #23 by refactoring the method by which we persist focus on the input field.

Instead of capturing events globally, we ensure that the input field is always focused. 

The PR also brings in a few related changes, including
- Let the AdminBar be a `<Form />` element (automatically submits form when pressing Enter, and gives a "Submit" key on mobile keyboards)
- Add a bit of horizontal padding to the input (I noticed we haven't set the global box-sizing to border-box. I suggest doing so, and instead explicitly setting it to content-box if needed).

PTAL and see what you think @OskarDamkjaer 